### PR TITLE
Adding OpenSSL Ed25519 PEM support

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -43,6 +43,10 @@ pub fn parse_keystr(pem: &[u8], passphrase: Option<&str>) -> OsshResult<KeyPair>
             // Openssl EC Key
             pem::parse_pem_privkey(pem, passphrase)
         }
+        "BEGIN PRIVATE KEY" => {
+            // Openssl Ed25519 Key
+            pem::parse_pem_privkey(pem, passphrase)
+        }
         _ => Err(ErrorKind::UnsupportType.into()),
     }
 }

--- a/src/format/pem.rs
+++ b/src/format/pem.rs
@@ -42,14 +42,16 @@ pub fn stringify_pem_privkey(keypair: &KeyPair, passphrase: Option<&str>) -> Oss
             KeyPairType::ECDSA(key) => key
                 .ossl_ec()
                 .private_key_to_pem_passphrase(cipher, passphrase)?,
-            _ => return Err(ErrorKind::UnsupportType.into()),
+            KeyPairType::ED25519(key) => key
+                .ossl_pkey()?
+                .private_key_to_pem_pkcs8_passphrase(cipher, passphrase)?,
         }
     } else {
         match &keypair.key {
             KeyPairType::RSA(key) => key.ossl_rsa().private_key_to_pem()?,
             KeyPairType::DSA(key) => key.ossl_dsa().private_key_to_pem()?,
             KeyPairType::ECDSA(key) => key.ossl_ec().private_key_to_pem()?,
-            _ => return Err(ErrorKind::UnsupportType.into()),
+            KeyPairType::ED25519(key) => key.ossl_pkey()?.private_key_to_pem_pkcs8()?,
         }
     };
 
@@ -72,7 +74,7 @@ pub fn stringify_pem_pubkey(pubkey: &PublicKey) -> OsshResult<String> {
         PublicKeyType::RSA(key) => key.ossl_rsa().public_key_to_pem_pkcs1()?,
         PublicKeyType::DSA(key) => key.ossl_pkey()?.public_key_to_pem()?,
         PublicKeyType::ECDSA(key) => key.ossl_pkey()?.public_key_to_pem()?,
-        _ => return Err(ErrorKind::UnsupportType.into()),
+        PublicKeyType::ED25519(key) => key.ossl_pkey()?.public_key_to_pem()?,
     };
 
     String::from_utf8(pem).map_err(|e| Error::with_error(ErrorKind::InvalidPemFormat, e))

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -116,6 +116,7 @@ impl PublicKey {
             }
             Id::DSA => Ok(dsa::DsaPublicKey::from_ossl_dsa(pkey.dsa()?).into()),
             Id::EC => Ok(ecdsa::EcDsaPublicKey::from_ossl_ec(pkey.ec_key()?)?.into()),
+            Id::ED25519 => Ok(ed25519::Ed25519PublicKey::from_ossl_ed25519(&pkey.raw_public_key()?)?.into()),
             _ => Err(ErrorKind::UnsupportType.into()),
         }
     }
@@ -162,7 +163,7 @@ impl PublicKey {
     /// - Begin with `-----BEGIN PUBLIC KEY-----` for dsa key.
     /// - Begin with `-----BEGIN RSA PUBLIC KEY-----` for rsa key.
     /// - Begin with `-----BEGIN PUBLIC KEY-----` for ecdsa key.
-    /// - This format doesn't support Ed25519
+    /// - Begin with `-----BEGIN PUBLIC KEY-----` for ed25519 key.
     ///
     /// # Note
     /// This format cannot store the comment!
@@ -269,6 +270,7 @@ impl KeyPair {
             }
             Id::DSA => Ok(dsa::DsaKeyPair::from_ossl_dsa(pkey.dsa()?).into()),
             Id::EC => Ok(ecdsa::EcDsaKeyPair::from_ossl_ec(pkey.ec_key()?)?.into()),
+            Id::ED25519 => Ok(ed25519::Ed25519KeyPair::from_ossl_ed25519(&pkey.raw_private_key()?)?.into()),
             _ => Err(ErrorKind::UnsupportType.into()),
         }
     }
@@ -278,7 +280,7 @@ impl KeyPair {
             KeyPairType::RSA(key) => Ok(PKey::from_rsa(key.ossl_rsa().to_owned())?),
             KeyPairType::DSA(key) => Ok(PKey::from_dsa(key.ossl_dsa().to_owned())?),
             KeyPairType::ECDSA(key) => Ok(PKey::from_ec_key(key.ossl_ec().to_owned())?),
-            _ => Err(ErrorKind::UnsupportType.into()),
+            KeyPairType::ED25519(key) => Ok(key.ossl_pkey()?),
         }
     }
 
@@ -290,7 +292,7 @@ impl KeyPair {
     /// - Begin with `-----BEGIN DSA PRIVATE KEY-----` for dsa key.
     /// - Begin with `-----BEGIN RSA PRIVATE KEY-----` for rsa key.
     /// - Begin with `-----BEGIN EC PRIVATE KEY-----` for ecdsa key.
-    /// - This file type doesn't support Ed25519
+    /// - Begin with `-----BEGIN PRIVATE KEY-----` for Ed25519 key.
     ///
     /// # PKCS#8 Format
     /// - Begin with `-----BEGIN PRIVATE KEY-----`


### PR DESCRIPTION
I needed Ed25519 Key support to decode from PEM and encode and I used OpenSSL for that in my own code. So when I switched to this library I missed the Ed25519 support for PEM. I modified the library to use the OpenSSL functions available. May need a bit more testing but it already works for my purposes and the functions I do not know if they are the correct ones (private Key to PEM PKCS8) but there are no others in that Struct so I guess they are the right ones.